### PR TITLE
Fixing #1 | Added auto-scrolling feature that scrolls and keeps currently typed row in the middle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# environment
+.env

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,12 +2,11 @@
 import TypingOverlayComponent from './Typing'
 
 function App() {
-
   return (
-    <div style={{width: "100vw", height: "100vh",       }}>
+    <div style={{ width: "100vw", height: "100vh" }}>
       <TypingOverlayComponent />
     </div>
   );
 }
 
-export default App
+export default App;

--- a/src/Typing.jsx
+++ b/src/Typing.jsx
@@ -61,7 +61,7 @@ export default function TypingOverlayComponent() {
   // Autoscroll to set typable character in the middle
   useEffect(() => {
     autoScrollFocusRef.current?.scrollIntoView({
-      behavior: "instant",
+      behavior: "smooth",
       block: "center",
     });
   }, [typable]);
@@ -274,11 +274,9 @@ export default function TypingOverlayComponent() {
           paddingInline: TYPABLE_PARENT_X_PADDING, // X-axis padding (left and right)
           textAlign: "left",
           wordBreak: "break-word",
-          maxHeight: "150px",
+          maxHeight: "140px",
           overflowY: "scroll",
-          overflowX: "hidden",
-          border: "2px solid black",
-          borderRadius: "10px 0px 0px 10px",
+          overflow: "hidden",
         }}
       >
         <div

--- a/src/Typing.jsx
+++ b/src/Typing.jsx
@@ -6,12 +6,12 @@ import SpanComponent from "./components/SpanComponent";
 import { motion } from "framer-motion";
 
 export default function TypingOverlayComponent() {
-  const FIXED_TIME = Number(import.meta.env.VITE_TEST_DURATION_IN_SECONDS);
+  const FIXED_TIME = Number(import.meta.env.VITE_TEST_DURATION_IN_SECONDS) || 30;
   const TYPABLE_PARENT_Y_PADDING = 10;
   const TYPABLE_PARENT_X_PADDING = 20;
 
-  const unTypedRef = useRef(new Stack());
-  const typedRef = useRef(new Stack());
+  const unTypedRef = useRef(Stack());
+  const typedRef = useRef(Stack());
   const inputRef = useRef(null);
   const autoScrollFocusRef = useRef(null);
   const interval = useRef(null);
@@ -37,7 +37,7 @@ export default function TypingOverlayComponent() {
         setTimer((prev) => prev - 1);
       }, 1000);
 
-      if (unTypedRef.current.size() == 0 || timer <= 0) {
+      if (unTypedRef.current.isEmpty() || timer <= 0) {
         clearInterval(interval.current);
       }
     }
@@ -144,7 +144,7 @@ export default function TypingOverlayComponent() {
 
   const checkTyped = useCallback((typedChar) => {
     // Returns if there is nothing to type
-    if (unTypedRef.current.size() == 0) {
+    if (unTypedRef.current.isEmpty()) {
       return;
     }
     const unTypedCharSpan = unTypedRef.current.pop();
@@ -200,7 +200,7 @@ export default function TypingOverlayComponent() {
       const typedChar = inputText[inputText.length - 1];
       checkTyped(typedChar);
     }
-    if (!(unTypedRef.current.size() == 0 || timer <= 0)) {
+    if (!(unTypedRef.current.isEmpty() || timer <= 0)) {
       setUserInput( inputText.slice(0, unTypedRef.current.size() + typedRef.current.size()) );
     }
   };
@@ -295,7 +295,7 @@ export default function TypingOverlayComponent() {
             <SpanComponent key={0} color={ETextColor.UNTYPED} char="Loading text..."/>
           )}
         </div>
-        {!(unTypedRef.current.size() == 0 || timer <= 0) && (
+        {!(unTypedRef.current.isEmpty() || timer <= 0) && (
           <motion.div
             animate={{ opacity: [0, 1] }}
             transition={{
@@ -319,7 +319,7 @@ export default function TypingOverlayComponent() {
         ref={inputRef}
         type="text"
         onChange={handleInputChange}
-        disabled={unTypedRef.current.size() == 0 || timer <= 0}
+        disabled={unTypedRef.current.isEmpty() || timer <= 0}
         style={{
           position: "absolute",
           top: 0,
@@ -331,7 +331,7 @@ export default function TypingOverlayComponent() {
         }}
       />
 
-      {(unTypedRef.current.size() == 0 || timer <= 0) && (
+      {(unTypedRef.current.isEmpty() || timer <= 0) && (
         <div style={{ marginTop: "20px", fontSize: "18px" }}>
           You typed {wordCount} word{wordCount !== 1 && "s"} in {elapsedTime} seconds!
         </div>

--- a/src/Typing.jsx
+++ b/src/Typing.jsx
@@ -1,73 +1,218 @@
-import React, { useState, useEffect, useRef, useMemo } from "react";
-import { motion } from "framer-motion";
+import { useCallback, useEffect, useRef, useState } from "react";
+import Stack from "./utils/collections/Stack";
 import animeNames from "./data";
+import { ETextColor } from "./utils/enums/cssEnums";
+import SpanComponent from "./components/SpanComponent";
+import { motion } from "framer-motion";
 
-const TypingOverlayComponent = () => {
-  const [textToType, setTextToType] = useState("Demo");
-  const [userInput, setUserInput] = useState("");
-  const [caretPosition, setCaretPosition] = useState({ top: 0, left: 0 });
-  const [timer, setTimer] = useState(30);
-  const [isTypingAllowed, setIsTypingAllowed] = useState(true);
-  const [wordCount, setWordCount] = useState(0);
-  const [hasStartedTyping, setHasStartedTyping] = useState(false);
+export default function TypingOverlayComponent() {
+  const FIXED_TIME = Number(import.meta.env.VITE_TEST_DURATION_IN_SECONDS);
+  const TYPABLE_PARENT_Y_PADDING = 10;
+  const TYPABLE_PARENT_X_PADDING = 20;
 
-  const textRef = useRef(null);
-  const caretRef = useRef(null);
+  const unTypedRef = useRef(new Stack());
+  const typedRef = useRef(new Stack());
   const inputRef = useRef(null);
+  const autoScrollFocusRef = useRef(null);
+  const interval = useRef(null);
+  const textRef = useRef(null);
 
-  // List of anime names for dynamic selection
-
-  // Fetch random anime quote
-  const fetchAnimeQuote = useMemo(() => async () => {
-    try {
-      // Select a random anime name
-      const randomAnime = animeNames[Math.floor(Math.random() * animeNames.length)];
-      const apiUrl = `https://kitsu.io/api/edge/anime?filter[text]=${randomAnime}&page[number]=1&page[size]=2`;
-
-      const response = await fetch(apiUrl);
-      const data = await response.json();
-
-      const firstAnime = data.data?.[0];
-      const synopsis = firstAnime?.attributes?.synopsis || "No synopsis available.";
-
-      setTextToType(synopsis);
-    } catch (err) {
-      console.error("Error fetching anime quote:", err);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchAnimeQuote();
-  }, [fetchAnimeQuote]);
-
-  useEffect(() => {
-    if (inputRef.current) {
-      inputRef.current.focus();
-    }
-  }, []);
-
-  useEffect(() => {
-    let interval = null;
-    if (hasStartedTyping && timer > 0) {
-      interval = setInterval(() => {
-        setTimer((prev) => prev - 1);
-      }, 1000);
-
-      if (timer <= 0) {
-        setIsTypingAllowed(false);
-        clearInterval(interval);
-      }
-    }
-    return () => clearInterval(interval);
-  }, [hasStartedTyping, timer]);
+  const [timer, setTimer] = useState(FIXED_TIME);
+  const [elapsedTime, setElapsedTime] = useState(0);
+  const [hasStartedTyping, setHasStartedTyping] = useState(false);
+  const [userInput, setUserInput] = useState("");
+  const [wordCount, setWordCount] = useState(0);
+  const [typable, setTypable] = useState([]);
+  const [caretPosition, setCaretPosition] = useState({ top: 0, left: 0 });
 
   useEffect(() => {
     setWordCount(userInput.trim().split(/\s+/).filter(Boolean).length);
   }, [userInput]);
 
+  // This runs the timer
   useEffect(() => {
-    updateCaretPosition();
-  }, [userInput]);
+    if (hasStartedTyping && timer > 0) {
+      interval.current = setInterval(() => {
+        setElapsedTime(FIXED_TIME - timer.valueOf() + 1);
+        setTimer((prev) => prev - 1);
+      }, 1000);
+
+      if (unTypedRef.current.size() == 0 || timer <= 0) {
+        clearInterval(interval.current);
+      }
+    }
+    return () => clearInterval(interval.current);
+  }, [hasStartedTyping, timer]);
+
+  // Clear typed and unTyped stacks
+  useEffect(() => {
+    unTypedRef.current.clear();
+    typedRef.current.clear();
+  }, []);
+
+  const updateTypable = (index, newValue) => {
+    setTypable((prev) => {
+      const updatedArray = [...prev]; // Create a copy of the array
+      updatedArray[index] = newValue; // Update the specific index
+      return updatedArray; // Return the updated array
+    });
+  };
+
+  // Autoscroll to set typable character in the middle
+  useEffect(() => {
+    autoScrollFocusRef.current?.scrollIntoView({
+      behavior: "instant",
+      block: "center",
+    });
+  }, [typable]);
+
+  const generateTypableSpan = useCallback((text) => {
+    try {
+      const array = text.split("");
+      return array.map((char, index) => {
+        // autoScrollFocusRef is set to firstElement
+        const firstElement = index == 0;
+
+        return (
+          <SpanComponent key={index} color={ETextColor.UNTYPED} char={char}
+            ref={ firstElement ? (rf) => { autoScrollFocusRef.current = rf; } : null }
+          />
+        );
+      });
+    } catch (err) {
+      console.error("Error while generating span: ", err);
+      // Optionally, set some state to indicate an error
+      setTypable(
+        <SpanComponent key={0} color={ETextColor.UNTYPED} 
+          char="Failed to generate character span. Please try again."
+        />
+      );
+    }
+  }, []);
+
+  const getAnimeSynopsis = useCallback(async () => {
+    try {
+      // Select a random anime name
+      const randomAnimeName = animeNames[Math.floor(Math.random() * animeNames.length)];
+      // Encodes a text string as a valid component of a Uniform Resource Identifier (URI)
+      const encodedAnimeName = encodeURIComponent(randomAnimeName);
+
+      const apiUrl = `https://kitsu.io/api/edge/anime?filter[text]=${encodedAnimeName}&page[number]=1&page[size]=2`;
+
+      const response = await fetch(apiUrl);
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      const data = await response.json();
+
+      const firstAnime = data.data?.[0];
+      const synopsis = firstAnime?.attributes?.synopsis || "No synopsis available.";
+      return synopsis;
+    } catch (err) {
+      console.error("Error fetching anime quote: ", err);
+      // Optionally, set some state to indicate an error
+      setTypable(
+        <SpanComponent key={0} color={ETextColor.UNTYPED}
+          char="Failed to fetch anime quote. Please try again."
+        />
+      );
+    }
+  }, []);
+
+  const fetchAnimeQuote = useCallback(async () => {
+    try {
+      const synopsis = await getAnimeSynopsis();
+      const typableSpan = generateTypableSpan(synopsis);
+      // Reverse typableSpan and stack it as unTyped
+      for (let i = typableSpan.length - 1; i >= 0; i--) unTypedRef.current.push(typableSpan[i]);
+      // This will be displayed on screen
+      setTypable(typableSpan);
+    } catch (err) {
+      console.error("Error during stack operation: ", err);
+      // Optionally, set some state to indicate an error
+      setTypable(
+        <SpanComponent key={0} color={ETextColor.UNTYPED}
+          char="Stack operation failed. Please try again."
+        />
+      );
+    }
+  }, [generateTypableSpan, getAnimeSynopsis]);
+
+  useEffect(() => {
+    fetchAnimeQuote();
+  }, [fetchAnimeQuote]);
+
+  const checkTyped = useCallback((typedChar) => {
+    // Returns if there is nothing to type
+    if (unTypedRef.current.size() == 0) {
+      return;
+    }
+    const unTypedCharSpan = unTypedRef.current.pop();
+
+    const spanKey = unTypedCharSpan.key;
+    const unTypedChar = unTypedCharSpan.props.char;
+
+    let color = "";
+
+    if (typedChar === unTypedChar) {
+      // Character match
+      color = ETextColor.CORRECT;
+    } else {
+      // Character mismatch
+      color = ETextColor.WRONG;
+    }
+    const typedCharSpan = (
+      <SpanComponent key={spanKey} color={color} char={unTypedChar} 
+        ref={(rf) => { autoScrollFocusRef.current = rf; }}
+      />
+    );
+
+    typedRef.current.push(typedCharSpan);
+    updateTypable(spanKey, typedCharSpan);
+  }, []);
+
+  const handleBackSpace = useCallback(() =>   {
+    const typedCharSpan = typedRef.current.pop();
+    const spanKey = typedCharSpan.key;
+    const typedChar = typedCharSpan.props.char;
+
+    // Converting typed to unTypedCharSpan
+    const unTypedCharSpan = (
+      <SpanComponent key={spanKey} color={ETextColor.UNTYPED} char={typedChar}
+        ref={(rf) => { autoScrollFocusRef.current = rf; }}
+      />
+    );
+
+    unTypedRef.current.push(unTypedCharSpan);
+    updateTypable(spanKey, unTypedCharSpan);
+  }, []);
+
+  const handleInputChange = (e) => {
+    e.preventDefault();
+    if (!hasStartedTyping) {
+      setHasStartedTyping(true);
+    }
+    const inputText = e.target.value;
+    // Backspace was clicked
+    if (inputText.length < typedRef.current.size()) {
+      handleBackSpace();
+    } else {
+      const typedChar = inputText[inputText.length - 1];
+      checkTyped(typedChar);
+    }
+    if (!(unTypedRef.current.size() == 0 || timer <= 0)) {
+      setUserInput( inputText.slice(0, unTypedRef.current.size() + typedRef.current.size()) );
+    }
+  };
+
+  const setFocusOnInput = useCallback(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // Sets focus on input as soon as page loads
+  useEffect(() => {
+    setFocusOnInput();
+  }, [setFocusOnInput, unTypedRef.current.size()]);
 
   const updateCaretPosition = () => {
     const spans = textRef.current.querySelectorAll("span");
@@ -80,7 +225,7 @@ const TypingOverlayComponent = () => {
         top: rect.top - containerRect.top,
         left: rect.left - containerRect.left,
       });
-    } else if (userInput.length === textToType.length) {
+    } else if ( userInput.length === unTypedRef.current.size() + typedRef.current.size() ) {
       const lastChar = spans[spans.length - 1];
       const rect = lastChar.getBoundingClientRect();
       const containerRect = textRef.current.getBoundingClientRect();
@@ -91,34 +236,9 @@ const TypingOverlayComponent = () => {
     }
   };
 
-  const handleInputChange = (e) => {
-    const input = e.target.value;
-
-    if (input?.length === textToType?.length || timer <= 0) {
-      setIsTypingAllowed(false);
-    }
-
-    if (!hasStartedTyping) {
-      setHasStartedTyping(true);
-    }
-
-    if (isTypingAllowed) {
-      setUserInput(input.slice(0, textToType.length));
-    }
-  };
-
-  const getStyledText = () => {
-    return textToType.split("").map((char, index) => {
-      const isCorrect = userInput[index] === char;
-      const isTyped = index < userInput.length;
-      const color = isTyped ? (isCorrect ? "green" : "red") : "gray";
-      return (
-        <span key={index} style={{ color, whiteSpace: "pre" }}>
-          {char}
-        </span>
-      );
-    });
-  };
+  useEffect(() => {
+    updateCaretPosition();
+  }, [userInput]);
 
   return (
     <div
@@ -143,20 +263,25 @@ const TypingOverlayComponent = () => {
       </div>
 
       <div
+        onClick={setFocusOnInput}
         style={{
           position: "relative",
           width: "100%",
           fontFamily: "Courier New, monospace",
           fontSize: "2rem",
           lineHeight: "1.5",
+          paddingBlock: TYPABLE_PARENT_Y_PADDING, // Y-axis padding (top and bottom)
+          paddingInline: TYPABLE_PARENT_X_PADDING, // X-axis padding (left and right)
           textAlign: "left",
           wordBreak: "break-word",
           maxHeight: "150px",
           overflowY: "scroll",
           overflowX: "hidden",
+          border: "2px solid black",
+          borderRadius: "10px 0px 0px 10px",
         }}
       >
-        <p
+        <div
           ref={textRef}
           style={{
             position: "relative",
@@ -165,52 +290,52 @@ const TypingOverlayComponent = () => {
             wordBreak: "break-word",
           }}
         >
-          {getStyledText()}
-        </p>
-
-        <motion.div
-          ref={caretRef}
-          animate={{ opacity: [0, 1] }}
-          transition={{
-            repeat: Infinity,
-            duration: 0.8,
-            ease: "ease-in",
-          }}
-          style={{
-            position: "absolute",
-            top: caretPosition.top,
-            left: caretPosition.left,
-            backgroundColor: "yellow",
-            width: "2px",
-            height: "1em",
-          }}
-        />
-
-        <input
-          ref={inputRef}
-          type="text"
-          value={userInput}
-          onChange={handleInputChange}
-          disabled={!isTypingAllowed}
-          style={{
-            position: "absolute",
-            top: 0,
-            left: 0,
-            opacity: 0,
-            width: "100%",
-            height: "100%",
-            caretColor: "transparent",
-          }}
-        />
+          {typable.length > 0 ? ( typable ) 
+          : (
+            <SpanComponent key={0} color={ETextColor.UNTYPED} char="Loading text..."/>
+          )}
+        </div>
+        {!(unTypedRef.current.size() == 0 || timer <= 0) && (
+          <motion.div
+            animate={{ opacity: [0, 1] }}
+            transition={{
+              repeat: Infinity,
+              duration: 0.8,
+              ease: "easeIn",
+            }}
+            style={{
+              position: "absolute",
+              top: caretPosition.top + TYPABLE_PARENT_Y_PADDING,
+              left: caretPosition.left + TYPABLE_PARENT_X_PADDING,
+              backgroundColor: "yellow",
+              width: "2px",
+              height: "1em",
+            }}
+          />
+        )}
       </div>
 
-      {!isTypingAllowed && (
+      <input
+        ref={inputRef}
+        type="text"
+        onChange={handleInputChange}
+        disabled={unTypedRef.current.size() == 0 || timer <= 0}
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          opacity: 0,
+          width: "0%",
+          height: "0%",
+          caretColor: "transparent",
+        }}
+      />
+
+      {(unTypedRef.current.size() == 0 || timer <= 0) && (
         <div style={{ marginTop: "20px", fontSize: "18px" }}>
-          You typed {wordCount} word{wordCount !== 1 && "s"} in 30 seconds!
+          You typed {wordCount} word{wordCount !== 1 && "s"} in {elapsedTime} seconds!
         </div>
       )}
     </div>
   );
-};
-
-export default TypingOverlayComponent;
+}

--- a/src/components/SpanComponent.jsx
+++ b/src/components/SpanComponent.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const SpanComponent = React.forwardRef(({ color, char }, ref) => {
+  return (
+    <span ref={ref} style={{ color, whiteSpace: "pre" }}>
+      {char}
+    </span>
+  );
+});
+
+// Add a display name for debugging purposes
+SpanComponent.displayName = "SpanComponent";
+
+SpanComponent.propTypes = {
+  color: PropTypes.string.isRequired, // Ensures color is a string
+  char: PropTypes.string.isRequired, // Ensures char is a string
+};
+
+export default SpanComponent;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.jsx'
+// import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./index.css";
+import App from "./App.jsx";
 
-createRoot(document.getElementById('root')).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+createRoot(document.getElementById("root")).render(
+  // <StrictMode>
+  <App />
+  // </StrictMode>
+);

--- a/src/utils/collections/Stack.js
+++ b/src/utils/collections/Stack.js
@@ -1,38 +1,35 @@
-export default class Stack {
-    constructor() {
-      this.items = [];
-    }
+const Stack = () => {
+  let items = [];
+
+  const isEmpty = () => items.length === 0;
   
-    isEmpty() {
-      return this.size() == 0;
-    }
+  const size = () => items.length;
   
-    size() {
-      return this.items.length;
-    }
+  const clear = () => {
+    items = [];
+  };
   
-    clear() {
-      this.items = [];
-    }
+  const push = (item) => {
+    items.push(item);
+  };
   
-    push(item) {
-      this.items.push(item);
-    }
+  const pop = () => {
+    if (isEmpty()) throw new Error("Stack is Empty!");
+    return items.pop();
+  };
   
-    pop() {
-      if (this.isEmpty()) throw new Error("Stack is Empty!");
-      return this.items.pop();
-    }
+  const peek = () => {
+    if (isEmpty()) throw new Error("Stack is Empty!");
+    return items[items.length - 1];
+  };
   
-    peek() {
-      if (this.isEmpty()) throw new Error("Stack is Empty!");
-      return this.items[this.items.length - 1];
-    }
-    print() {
-      for (let i = this.items.length - 1; i >= 0; i--) console.log(this.items[i]);
-    }
+  const print = () => {
+    for (let i = items.length - 1; i >= 0; i--) console.log(items[i]);
+  };
   
-    getStack() {
-      return this.items;
-    }
-  }
+  const getStack = () => items;
+
+  return { isEmpty, size, clear, push, pop, peek, print, getStack };
+};
+
+export default Stack;

--- a/src/utils/collections/Stack.js
+++ b/src/utils/collections/Stack.js
@@ -1,0 +1,38 @@
+export default class Stack {
+    constructor() {
+      this.items = [];
+    }
+  
+    isEmpty() {
+      return this.size() == 0;
+    }
+  
+    size() {
+      return this.items.length;
+    }
+  
+    clear() {
+      this.items = [];
+    }
+  
+    push(item) {
+      this.items.push(item);
+    }
+  
+    pop() {
+      if (this.isEmpty()) throw new Error("Stack is Empty!");
+      return this.items.pop();
+    }
+  
+    peek() {
+      if (this.isEmpty()) throw new Error("Stack is Empty!");
+      return this.items[this.items.length - 1];
+    }
+    print() {
+      for (let i = this.items.length - 1; i >= 0; i--) console.log(this.items[i]);
+    }
+  
+    getStack() {
+      return this.items;
+    }
+  }

--- a/src/utils/enums/cssEnums.js
+++ b/src/utils/enums/cssEnums.js
@@ -1,0 +1,5 @@
+export const ETextColor = Object.freeze({
+    UNTYPED: "gray",
+    CORRECT: "green",
+    WRONG: "red",
+  });


### PR DESCRIPTION
Fixes #1 

This video shows the newly added auto-scrolling feature and some minor bug fixes mentioned below in description

![added-auto-scrolling](https://github.com/user-attachments/assets/15810bba-f75e-4503-abc9-f945561c463d)

**Description**
- Auto scrolling works while typing normally (moves downwards) and while clicking 'backspace' button
- Scrolling using scrollIntoView api (this works only with DOM elements)
- Timer now stops when timer runs to 0 or if there's no more text left to type
- Avoiding function reference re-renders by using useCallback hook
- Created a new component for generating individual character span elements
- Post typing result now shows elapsed time instead of a placeholder time
- Test duration now has to be set in .env under the name 'VITE_TEST_DURATION_IN_SECONDS'
- Tracking typed text status by using two stacks i.e., typed and unTyped
- focusing on input when page reloads and when user clicks on scrollable div after input loses focus
- Caret now disables after test is completed
- input element is hidden on the top left corner with 0 width and height
- Created ETextColor enum to maintain typable text color states (UNTYPED, CORRECT, WRONG)